### PR TITLE
assembly: fix error in aclose & fix type checking

### DIFF
--- a/livekit-plugins/livekit-plugins-assemblyai/setup.py
+++ b/livekit-plugins/livekit-plugins-assemblyai/setup.py
@@ -25,7 +25,7 @@ with open(os.path.join(here, "livekit", "plugins", "assemblyai", "version.py"), 
 setuptools.setup(
     name="livekit-plugins-assemblyai",
     version=about["__version__"],
-    description="Agent Framework plugin for AssemblyAI",
+    description="Agent Framework plugin for services using AssemblyAI's API.",
     long_description=(here / "README.md").read_text(encoding="utf-8"),
     long_description_content_type="text/markdown",
     url="https://github.com/livekit/agents",
@@ -45,10 +45,8 @@ setuptools.setup(
     license="Apache-2.0",
     packages=setuptools.find_namespace_packages(include=["livekit.*"]),
     python_requires=">=3.9.0",
-    install_requires=[
-        "livekit-agents~=0.7",
-    ],
-    package_data={},
+    install_requires=["livekit-agents>=0.8.0", "numpy~=1.21"],
+    package_data={"livekit.plugins.assemblyai": ["py.typed"]},
     project_urls={
         "Documentation": "https://docs.livekit.io",
         "Website": "https://livekit.io/",


### PR DESCRIPTION
Looks like the API changed since their PR was drafted, so aclose no longer works as written, causing this erro https://portola.sentry.io/issues/5919721168/?project=4507574818504704&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&statsPeriod=14d&stream_index=22

While I was here, added py.typed, updated setup.py, and fixed some typing issues caused by other LK API changes.