### PR TITLE
agent: Amend committed messages with same ID

### DIFF
--- a/.changeset/clean-laws-explode.md
+++ b/.changeset/clean-laws-explode.md
@@ -1,0 +1,7 @@
+---
+"livekit-plugins-anthropic": patch
+"livekit-plugins-openai": patch
+"livekit-agents": patch
+---
+
+added inference_id to llm chat method signature

--- a/.changeset/empty-mice-cheer.md
+++ b/.changeset/empty-mice-cheer.md
@@ -1,0 +1,5 @@
+---
+"livekit-plugins-elevenlabs": patch
+---
+
+add try_trigger_generation option

--- a/.changeset/six-apricots-study.md
+++ b/.changeset/six-apricots-study.md
@@ -1,0 +1,5 @@
+---
+"livekit-agents": patch
+---
+
+add inference id

--- a/livekit-agents/livekit/agents/llm/chat_context.py
+++ b/livekit-agents/livekit/agents/llm/chat_context.py
@@ -51,6 +51,7 @@ class ChatMessage:
     tool_calls: list[function_context.FunctionCallInfo] | None = None
     tool_call_id: str | None = None
     tool_exception: Exception | None = None
+    inference_id: str | None = None
     _metadata: dict[str, Any] = field(default_factory=dict, repr=False, init=False)
 
     @staticmethod
@@ -86,10 +87,14 @@ class ChatMessage:
 
     @staticmethod
     def create(
-        *, text: str = "", images: list[ChatImage] = [], role: ChatRole = "system"
+        *,
+        text: str = "",
+        images: list[ChatImage] = [],
+        role: ChatRole = "system",
+        inference_id: str | None = None,
     ) -> "ChatMessage":
         if len(images) == 0:
-            return ChatMessage(role=role, content=text)
+            return ChatMessage(role=role, content=text, inference_id=inference_id)
         else:
             content: list[ChatContent] = []
             if text:
@@ -98,7 +103,7 @@ class ChatMessage:
             if len(images) > 0:
                 content.extend(images)
 
-            return ChatMessage(role=role, content=content)
+            return ChatMessage(role=role, content=content, inference_id=inference_id)
 
     def copy(self):
         content = self.content
@@ -115,6 +120,7 @@ class ChatMessage:
             content=content,
             tool_calls=tool_calls,
             tool_call_id=self.tool_call_id,
+            inference_id=self.inference_id,
         )
         copied_msg._metadata = self._metadata
         return copied_msg
@@ -126,9 +132,18 @@ class ChatContext:
     _metadata: dict[str, Any] = field(default_factory=dict, repr=False, init=False)
 
     def append(
-        self, *, text: str = "", images: list[ChatImage] = [], role: ChatRole = "system"
+        self,
+        *,
+        text: str = "",
+        images: list[ChatImage] = [],
+        role: ChatRole = "system",
+        inference_id: str | None = None,
     ) -> ChatContext:
-        self.messages.append(ChatMessage.create(text=text, images=images, role=role))
+        self.messages.append(
+            ChatMessage.create(
+                text=text, images=images, role=role, inference_id=inference_id
+            )
+        )
         return self
 
     def copy(self) -> ChatContext:

--- a/livekit-agents/livekit/agents/llm/chat_context.py
+++ b/livekit-agents/livekit/agents/llm/chat_context.py
@@ -14,6 +14,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from datetime import datetime
 from typing import Any, Literal, Union
 
 from livekit import rtc
@@ -51,7 +52,7 @@ class ChatMessage:
     tool_calls: list[function_context.FunctionCallInfo] | None = None
     tool_call_id: str | None = None
     tool_exception: Exception | None = None
-    inference_id: str | None = None
+    timestamp: datetime | None = None
     _metadata: dict[str, Any] = field(default_factory=dict, repr=False, init=False)
 
     @staticmethod
@@ -91,10 +92,11 @@ class ChatMessage:
         text: str = "",
         images: list[ChatImage] = [],
         role: ChatRole = "system",
-        inference_id: str | None = None,
+        id: str | None = None,
+        timestamp: datetime | None = None,
     ) -> "ChatMessage":
         if len(images) == 0:
-            return ChatMessage(role=role, content=text, inference_id=inference_id)
+            return ChatMessage(role=role, content=text, id=id, timestamp=timestamp or datetime.now())
         else:
             content: list[ChatContent] = []
             if text:
@@ -103,7 +105,7 @@ class ChatMessage:
             if len(images) > 0:
                 content.extend(images)
 
-            return ChatMessage(role=role, content=content, inference_id=inference_id)
+            return ChatMessage(role=role, content=content, id=id, timestamp=timestamp or datetime.now())
 
     def copy(self):
         content = self.content
@@ -120,7 +122,8 @@ class ChatMessage:
             content=content,
             tool_calls=tool_calls,
             tool_call_id=self.tool_call_id,
-            inference_id=self.inference_id,
+            id=self.id,
+            timestamp=self.timestamp,
         )
         copied_msg._metadata = self._metadata
         return copied_msg
@@ -137,11 +140,12 @@ class ChatContext:
         text: str = "",
         images: list[ChatImage] = [],
         role: ChatRole = "system",
-        inference_id: str | None = None,
+        id: str | None = None,
+        timestamp: datetime | None = None,
     ) -> ChatContext:
         self.messages.append(
             ChatMessage.create(
-                text=text, images=images, role=role, inference_id=inference_id
+                text=text, images=images, role=role, id=id, timestamp=timestamp
             )
         )
         return self

--- a/livekit-agents/livekit/agents/llm/llm.py
+++ b/livekit-agents/livekit/agents/llm/llm.py
@@ -38,6 +38,7 @@ class LLM(abc.ABC):
         temperature: float | None = None,
         n: int | None = None,
         parallel_tool_calls: bool | None = None,
+        inference_id: str | None = None,
     ) -> "LLMStream": ...
 
 

--- a/livekit-agents/livekit/agents/pipeline/human_input.py
+++ b/livekit-agents/livekit/agents/pipeline/human_input.py
@@ -87,7 +87,10 @@ class HumanInput(utils.EventEmitter[EventTypes]):
                     self._recognize_atask.cancel()
 
                 self._recognize_atask = asyncio.create_task(
-                    self._recognize_task(rtc.AudioStream(track, sample_rate=16000))
+                    # <Portola> Historically sample rate has been the default (48KHz) but was changed in
+                    # https://github.com/livekit/agents/pull/920 to 16KHz, which we worry will increase word
+                    # error rate. So we reinstate 48KHz here.
+                    self._recognize_task(rtc.AudioStream(track, sample_rate=48000))
                 )
                 break
 

--- a/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
+++ b/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
@@ -20,7 +20,7 @@ from .plotter import AssistantPlotter
 from .speech_handle import SpeechHandle
 
 BeforeLLMCallback = Callable[
-    ["VoicePipelineAgent", ChatContext],
+    ["VoicePipelineAgent", ChatContext, Optional[str]],
     Union[Optional[LLMStream], Awaitable[Optional[LLMStream]], Literal[False]],
 ]
 
@@ -74,11 +74,12 @@ class AgentCallContext:
 
 
 def _default_before_llm_cb(
-    agent: VoicePipelineAgent, chat_ctx: ChatContext
+    agent: VoicePipelineAgent, chat_ctx: ChatContext, inference_id: Optional[str]
 ) -> LLMStream:
     return agent.llm.chat(
         chat_ctx=chat_ctx,
         fnc_ctx=agent.fnc_ctx,
+        inference_id=inference_id,
     )
 
 
@@ -334,6 +335,7 @@ class VoicePipelineAgent(utils.EventEmitter[EventTypes]):
         *,
         allow_interruptions: bool = True,
         add_to_chat_ctx: bool = True,
+        inference_id: str | None = None,
     ) -> None:
         """
         Play a speech source through the voice assistant.
@@ -347,7 +349,9 @@ class VoicePipelineAgent(utils.EventEmitter[EventTypes]):
         await self._track_published_fut
 
         new_handle = SpeechHandle.create_assistant_speech(
-            allow_interruptions=allow_interruptions, add_to_chat_ctx=add_to_chat_ctx
+            allow_interruptions=allow_interruptions,
+            add_to_chat_ctx=add_to_chat_ctx,
+            inference_id=inference_id,
         )
         synthesis_handle = self._synthesize_agent_speech(new_handle.id, source)
         new_handle.initialize(source=source, synthesis_handle=synthesis_handle)
@@ -555,6 +559,7 @@ class VoicePipelineAgent(utils.EventEmitter[EventTypes]):
                     ChatMessage.create(
                         text=playing_speech.synthesis_handle.tts_forwarder.played_text,
                         role="assistant",
+                        inference_id=playing_speech.id,
                     )
                 )
 
@@ -562,7 +567,7 @@ class VoicePipelineAgent(utils.EventEmitter[EventTypes]):
             ChatMessage.create(text=handle.user_question, role="user")
         )
 
-        llm_stream = self._opts.before_llm_cb(self, copied_ctx)
+        llm_stream = self._opts.before_llm_cb(self, copied_ctx, handle.id)
         if llm_stream is False:
             handle.cancel()
             return
@@ -572,7 +577,9 @@ class VoicePipelineAgent(utils.EventEmitter[EventTypes]):
 
         # fallback to default impl if no custom/user stream is returned
         if not isinstance(llm_stream, LLMStream):
-            llm_stream = _default_before_llm_cb(self, chat_ctx=copied_ctx)
+            llm_stream = _default_before_llm_cb(
+                self, chat_ctx=copied_ctx, inference_id=handle.id
+            )
 
         if handle.interrupted:
             return
@@ -747,7 +754,9 @@ class VoicePipelineAgent(utils.EventEmitter[EventTypes]):
             if interrupted:
                 collected_text += "..."
 
-            msg = ChatMessage.create(text=collected_text, role="assistant")
+            msg = ChatMessage.create(
+                text=collected_text, role="assistant", inference_id=speech_handle.id
+            )
             self._chat_ctx.messages.append(msg)
 
             speech_handle.mark_speech_commited()

--- a/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
+++ b/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
@@ -559,12 +559,12 @@ class VoicePipelineAgent(utils.EventEmitter[EventTypes]):
                     ChatMessage.create(
                         text=playing_speech.synthesis_handle.tts_forwarder.played_text,
                         role="assistant",
-                        inference_id=playing_speech.id,
+                        id=playing_speech.id,
                     )
                 )
 
         copied_ctx.messages.append(
-            ChatMessage.create(text=handle.user_question, role="user")
+            ChatMessage.create(text=handle.user_question, role="user", id=utils.message_id(), timestamp=handle.created_at)
         )
 
         llm_stream = self._opts.before_llm_cb(self, copied_ctx, handle.id)
@@ -647,7 +647,7 @@ class VoicePipelineAgent(utils.EventEmitter[EventTypes]):
             logger.debug(
                 "committed user transcript", extra={"user_transcript": user_question}
             )
-            user_msg = ChatMessage.create(text=user_question, role="user")
+            user_msg = ChatMessage.create(text=user_question, role="user", id=utils.message_id(), timestamp=speech_handle.created_at)
             self._chat_ctx.messages.append(user_msg)
             self.emit("user_speech_committed", user_msg)
 
@@ -755,7 +755,7 @@ class VoicePipelineAgent(utils.EventEmitter[EventTypes]):
                 collected_text += "..."
 
             msg = ChatMessage.create(
-                text=collected_text, role="assistant", inference_id=speech_handle.id
+                text=collected_text, role="assistant", id=speech_handle.id
             )
             self._chat_ctx.messages.append(msg)
 

--- a/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
+++ b/livekit-agents/livekit/agents/pipeline/pipeline_agent.py
@@ -757,7 +757,8 @@ class VoicePipelineAgent(utils.EventEmitter[EventTypes]):
             msg = ChatMessage.create(
                 text=collected_text, role="assistant", id=speech_handle.id
             )
-            self._chat_ctx.messages.append(msg)
+
+            self._chat_ctx.append_chat_message(msg)
 
             speech_handle.mark_speech_commited()
 

--- a/livekit-agents/livekit/agents/pipeline/speech_handle.py
+++ b/livekit-agents/livekit/agents/pipeline/speech_handle.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import datetime
 from typing import AsyncIterable
 
 from .. import utils
@@ -34,6 +35,7 @@ class SpeechHandle:
         # source and synthesis_handle are None until the speech is initialized
         self._source: str | LLMStream | AsyncIterable[str] | None = None
         self._synthesis_handle: SynthesisHandle | None = None
+        self._created_at = datetime.now()
 
     @staticmethod
     def create_assistant_reply(
@@ -56,7 +58,7 @@ class SpeechHandle:
             SpeechHandle: The created instance.
         """
         return SpeechHandle(
-            id=utils.shortuuid(),
+            id=utils.message_id(),
             allow_interruptions=allow_interruptions,
             add_to_chat_ctx=add_to_chat_ctx,
             is_reply=True,
@@ -85,7 +87,7 @@ class SpeechHandle:
             SpeechHandle: The created instance.
         """
         return SpeechHandle(
-            id=inference_id or utils.shortuuid(),
+            id=inference_id or utils.message_id(),
             allow_interruptions=allow_interruptions,
             add_to_chat_ctx=add_to_chat_ctx,
             is_reply=False,
@@ -173,6 +175,10 @@ class SpeechHandle:
         return self._init_fut.cancelled() or (
             self._synthesis_handle is not None and self._synthesis_handle.interrupted
         )
+
+    @property
+    def created_at(self) -> datetime:
+        return self._created_at
 
     def interrupt(self) -> None:
         if not self.allow_interruptions:

--- a/livekit-agents/livekit/agents/pipeline/speech_handle.py
+++ b/livekit-agents/livekit/agents/pipeline/speech_handle.py
@@ -42,6 +42,19 @@ class SpeechHandle:
         add_to_chat_ctx: bool,
         user_question: str,
     ) -> SpeechHandle:
+        """
+        Creates a SpeechHandle for an assistant message that is in response to something a human has said,
+        represented by `user_question` (though it may not be literally a question). Downstream callers should
+        use this instance's `id` as an inference identifier to connect LLM calls with chat messages.
+
+        Args:
+            allow_interruptions: Whether to allow interruptions during speech playback.
+            add_to_chat_ctx: Whether to add the speech to the chat context.
+            user_question: The user's utterance that led to this speech handle being created.
+
+        Returns:
+            SpeechHandle: The created instance.
+        """
         return SpeechHandle(
             id=utils.shortuuid(),
             allow_interruptions=allow_interruptions,
@@ -55,9 +68,24 @@ class SpeechHandle:
         *,
         allow_interruptions: bool,
         add_to_chat_ctx: bool,
+        inference_id: str | None = None,
     ) -> SpeechHandle:
+        """
+        Creates a SpeechHandle for an assistant message that is not in response to something the user says,
+        for example the opening message for an agent or an out-of-band interrupt. Because the LLM inference
+        happened before this instance was created
+
+        Args:
+            allow_interruptions: Whether to allow interruptions during speech playback.
+            add_to_chat_ctx: Whether to add the speech to the chat context.
+            inference_id: Optional ID provided by callers to connect speech chat message to inference requests.
+                          If not provided, a random ID will be generated.
+
+        Returns:
+            SpeechHandle: The created instance.
+        """
         return SpeechHandle(
-            id=utils.shortuuid(),
+            id=inference_id or utils.shortuuid(),
             allow_interruptions=allow_interruptions,
             add_to_chat_ctx=add_to_chat_ctx,
             is_reply=False,

--- a/livekit-agents/livekit/agents/utils/__init__.py
+++ b/livekit-agents/livekit/agents/utils/__init__.py
@@ -4,7 +4,7 @@ from . import aio, audio, codecs, http_context, images
 from .audio import AudioBuffer, combine_frames, merge_frames
 from .exp_filter import ExpFilter
 from .log import log_exceptions
-from .misc import shortuuid, time_ms
+from .misc import message_id, shortuuid, time_ms
 from .moving_average import MovingAverage
 
 EventEmitter = rtc.EventEmitter
@@ -24,4 +24,5 @@ __all__ = [
     "images",
     "audio",
     "aio",
+    "message_id",
 ]

--- a/livekit-agents/livekit/agents/utils/misc.py
+++ b/livekit-agents/livekit/agents/utils/misc.py
@@ -10,3 +10,11 @@ def time_ms() -> int:
 
 def shortuuid() -> str:
     return str(uuid.uuid4().hex)[:12]
+
+
+def message_id() -> str:
+    """<Portola> A globally unique, prefixed identifier for every message in the chat history.
+    
+    We do not use shortuuid() above because there is too high risk of collision.
+    """
+    return f"CM_{str(uuid.uuid4().hex)}"

--- a/livekit-plugins/livekit-plugins-anthropic/livekit/plugins/anthropic/llm.py
+++ b/livekit-plugins/livekit-plugins-anthropic/livekit/plugins/anthropic/llm.py
@@ -85,6 +85,7 @@ class LLM(llm.LLM):
         temperature: float | None = None,
         n: int | None = 1,
         parallel_tool_calls: bool | None = None,
+        inference_id: str | None = None,
     ) -> "LLMStream":
         if temperature is None:
             temperature = self._opts.temperature

--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
@@ -366,6 +366,7 @@ class SpeechStream(stt.SpeechStream):
         elif data["type"] == "Results":
             is_final_transcript = data["is_final"]
             is_endpoint = data["speech_final"]
+            request_id = data.get("metadata", {}).get("request_id")
 
             alts = live_transcription_to_speech_data(self._opts.language, data)
             # If, for some reason, we didn't get a SpeechStarted event but we got
@@ -380,6 +381,13 @@ class SpeechStream(stt.SpeechStream):
                     self._event_ch.send_nowait(start_event)
 
                 if is_final_transcript:
+                    logger.info(
+                        "deepgram: final transcript received",
+                        extra={
+                            "request_id": request_id,
+                            "text": alts[0].text if len(alts) > 0 else None,
+                        },
+                    )
                     final_event = stt.SpeechEvent(
                         type=stt.SpeechEventType.FINAL_TRANSCRIPT, alternatives=alts
                     )

--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
@@ -381,11 +381,26 @@ class SpeechStream(stt.SpeechStream):
                     self._event_ch.send_nowait(start_event)
 
                 if is_final_transcript:
+                    # We are confident these keys exist because they are checked in live_transcription_to_speech_data
+                    words = [
+                        {'text': word['word'], 'confidence': word['confidence']}
+                        for word in (data["channel"]["alternatives"][0]["words"] or [])
+                    ]
+                    word_confidences = [word['confidence'] for word in words]
+                    min_confidence = min(word_confidences)
+                    max_confidence = max(word_confidences)
+                    mean_confidence = sum(word_confidences) / len(word_confidences)
+
                     logger.info(
                         "deepgram: final transcript received",
                         extra={
                             "request_id": request_id,
-                            "text": alts[0].text if len(alts) > 0 else None,
+                            "text": alts[0].text,
+                            "confidence": alts[0].confidence,
+                            "min_confidence": min_confidence,
+                            "max_confidence": max_confidence,
+                            "mean_confidence": mean_confidence,
+                            "words": words,
                         },
                     )
                     final_event = stt.SpeechEvent(

--- a/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py
+++ b/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py
@@ -87,6 +87,7 @@ class _TTSOptions:
     word_tokenizer: tokenize.WordTokenizer
     chunk_length_schedule: list[int]
     enable_ssml_parsing: bool
+    try_trigger_generation: bool
 
 
 class TTS(tts.TTS):
@@ -102,8 +103,9 @@ class TTS(tts.TTS):
         word_tokenizer: tokenize.WordTokenizer = tokenize.basic.WordTokenizer(
             ignore_punctuation=False  # punctuation can help for intonation
         ),
-        enable_ssml_parsing: bool = False,
         chunk_length_schedule: list[int] = [80, 120, 200, 260],  # range is [50, 500]
+        enable_ssml_parsing: bool = False,
+        try_trigger_generation: bool = True,
         http_session: aiohttp.ClientSession | None = None,
         # deprecated
         model_id: TTSModels | str | None = None,
@@ -153,6 +155,7 @@ class TTS(tts.TTS):
             word_tokenizer=word_tokenizer,
             chunk_length_schedule=chunk_length_schedule,
             enable_ssml_parsing=enable_ssml_parsing,
+            try_trigger_generation=try_trigger_generation,
         )
         self._session = http_session
 
@@ -343,7 +346,7 @@ class SynthesizeStream(tts.SynthesizeStream):
         # 11labs protocol expects the first message to be an "init msg"
         init_pkt = dict(
             text=" ",
-            try_trigger_generation=True,
+            try_trigger_generation=self._opts.try_trigger_generation,
             voice_settings=_strip_nones(dataclasses.asdict(self._opts.voice.settings))
             if self._opts.voice.settings
             else None,

--- a/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py
+++ b/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py
@@ -20,7 +20,7 @@ import dataclasses
 import json
 import os
 from dataclasses import dataclass
-from typing import Any, List, Literal
+from typing import Any, List, Literal, Tuple, Union
 
 import aiohttp
 from livekit import rtc
@@ -88,7 +88,7 @@ class _TTSOptions:
     chunk_length_schedule: list[int]
     enable_ssml_parsing: bool
     try_trigger_generation: bool
-    flush_after_first_sentence: bool
+    flush_interval: Union[Literal['first-sentence', 'all-sentences', False], Tuple[int, ...]]
 
 class TTS(tts.TTS):
     def __init__(
@@ -106,7 +106,7 @@ class TTS(tts.TTS):
         chunk_length_schedule: list[int] = [80, 120, 200, 260],  # range is [50, 500]
         enable_ssml_parsing: bool = False,
         try_trigger_generation: bool = True,
-        flush_after_first_sentence: bool = False,
+        flush_interval: Union[Literal['first-sentence', 'all-sentences', False], Tuple[int, ...]] = False,
         http_session: aiohttp.ClientSession | None = None,
         # deprecated
         model_id: TTSModels | str | None = None,
@@ -157,7 +157,7 @@ class TTS(tts.TTS):
             chunk_length_schedule=chunk_length_schedule,
             enable_ssml_parsing=enable_ssml_parsing,
             try_trigger_generation=try_trigger_generation,
-            flush_after_first_sentence=flush_after_first_sentence,
+            flush_interval=flush_interval,
         )
         self._session = http_session
 
@@ -361,7 +361,8 @@ class SynthesizeStream(tts.SynthesizeStream):
 
         async def send_task():
             nonlocal eos_sent
-            has_flushed = False # whether we have ever told Eleven Labs to flush
+            num_flushes = 0 # the number of times we have told Eleven Labs to flush
+            num_sentences = 0
 
             xml_content = []
             async for data in word_stream:
@@ -382,17 +383,28 @@ class SynthesizeStream(tts.SynthesizeStream):
 
                 # try_trigger_generation=True is a bad practice, we expose
                 # chunk_length_schedule instead
-                # <Portola> We also choose to flush on the first sentence having been completed, if the option is enabled.
+                #
+                # <Portola> We chose to go much further and expose a configurable `flush_interval` param
+                # that gives us more control to configure when flushing occurs. There are a few options:
+                # - `all-sentences`: always flush whenever a sentence boundary is detected
+                # - `first-sentence`: flush after the first sentence is sent
+                # - tuple of ints: flush periodically, where the tuple is a list of sentence counts at which we flush
+                # - False: flush never (the default behavior)
+                is_sentence_boundary = text[-1] in ('!', '?', '.') # rough heuristic but matches our domain pretty well
+                num_sentences += int(is_sentence_boundary)
                 data_pkt = dict(
                     text=f"{text} ",  # must always end with a space
                     try_trigger_generation=False,
                     flush=(
-                        self._opts.flush_after_first_sentence
-                        and not has_flushed
-                        and text[-1] in ('!', '?', '.') # rough heuristic but matches our domain pretty well
+                        is_sentence_boundary
+                        and (
+                            self._opts.flush_interval == 'all-sentences'
+                            or (self._opts.flush_interval == 'first-sentence' and num_flushes == 0)
+                            or (isinstance(self._opts.flush_interval, tuple) and num_sentences in self._opts.flush_interval)
+                        )
                     )
                 )
-                has_flushed |= data_pkt["flush"]
+                num_flushes += int(data_pkt["flush"])
                 await ws_conn.send_str(json.dumps(data_pkt))
 
             if xml_content:

--- a/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py
+++ b/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py
@@ -88,7 +88,7 @@ class _TTSOptions:
     chunk_length_schedule: list[int]
     enable_ssml_parsing: bool
     try_trigger_generation: bool
-
+    flush_after_first_sentence: bool
 
 class TTS(tts.TTS):
     def __init__(
@@ -106,6 +106,7 @@ class TTS(tts.TTS):
         chunk_length_schedule: list[int] = [80, 120, 200, 260],  # range is [50, 500]
         enable_ssml_parsing: bool = False,
         try_trigger_generation: bool = True,
+        flush_after_first_sentence: bool = False,
         http_session: aiohttp.ClientSession | None = None,
         # deprecated
         model_id: TTSModels | str | None = None,
@@ -156,6 +157,7 @@ class TTS(tts.TTS):
             chunk_length_schedule=chunk_length_schedule,
             enable_ssml_parsing=enable_ssml_parsing,
             try_trigger_generation=try_trigger_generation,
+            flush_after_first_sentence=flush_after_first_sentence,
         )
         self._session = http_session
 
@@ -359,6 +361,7 @@ class SynthesizeStream(tts.SynthesizeStream):
 
         async def send_task():
             nonlocal eos_sent
+            has_flushed = False # whether we have ever told Eleven Labs to flush
 
             xml_content = []
             async for data in word_stream:
@@ -379,10 +382,17 @@ class SynthesizeStream(tts.SynthesizeStream):
 
                 # try_trigger_generation=True is a bad practice, we expose
                 # chunk_length_schedule instead
+                # <Portola> We also choose to flush on the first sentence having been completed, if the option is enabled.
                 data_pkt = dict(
                     text=f"{text} ",  # must always end with a space
                     try_trigger_generation=False,
+                    flush=(
+                        self._opts.flush_after_first_sentence
+                        and not has_flushed
+                        and text[-1] in ('!', '?', '.') # rough heuristic but matches our domain pretty well
+                    )
                 )
+                has_flushed |= data_pkt["flush"]
                 await ws_conn.send_str(json.dumps(data_pkt))
 
             if xml_content:

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/beta/assistant_llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/beta/assistant_llm.py
@@ -167,6 +167,7 @@ class AssistantLLM(llm.LLM):
         temperature: float | None = None,
         n: int | None = None,
         parallel_tool_calls: bool | None = None,
+        inference_id: str | None = None,
     ):
         if n is not None:
             logger.warning("OpenAI Assistants does not support the 'n' parameter")

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
@@ -450,6 +450,7 @@ class LLM(llm.LLM):
         temperature: float | None = None,
         n: int | None = 1,
         parallel_tool_calls: bool | None = None,
+        inference_id: str | None = None,
     ) -> "LLMStream":
         opts: dict[str, Any] = dict()
         if fnc_ctx and len(fnc_ctx.ai_functions) > 0:


### PR DESCRIPTION
Within a chat context, when adding a message with an inference ID that has already been seen, extend the original message instead of appending a duplicate. This should be pretty safe because we filter unsynced messages, which means that we won't reapply/resync a modified message. This just gives us a chance to modify a committed message while still in-flight, before having been committed.

(Will investigate whether I can make this modification, instead, in `livekit-worker`)